### PR TITLE
[1.x.x_4.5.x] Upgrading the maven bundle plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.5.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
## Purpose
The build is failing with the below error.
```
[ERROR] Bundle org.wso2.carbon.callhome:callhome:bundle:4.5.x_1.0.12-SNAPSHOT : Exception: 19
[ERROR] Bundle org.wso2.carbon.callhome:callhome:bundle:4.5.x_1.0.12-SNAPSHOT : Invalid class file META-INF/versions/9/module-info.class (java.lang.ArrayIndexOutOfBoundsException: 19)
[ERROR] Error(s) found in bundle configuration
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 41.881 s
[INFO] Finished at: 2022-05-13T10:38:45+00:00
[INFO] Final Memory: 59M/630M
[INFO] ------------------------------------------------------------------------
Waiting for Jenkins to finish collecting data
[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:3.2.0:bundle (default-bundle) on project callhome: Error(s) found in bundle configuration -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
```

According to [1], upgrading it to 3.5.0 solves the problem.

[1] https://stackoverflow.com/questions/50530927/maven-bundle-plugin-fails-with-invalid-class-file-module-info-class